### PR TITLE
Add support for counters

### DIFF
--- a/crates/layer/src/debug_annotations.rs
+++ b/crates/layer/src/debug_annotations.rs
@@ -48,10 +48,6 @@ impl FFIDebugAnnotations {
             doubles: self.doubles.as_slice(),
         }
     }
-
-    pub fn take_counters(&mut self) -> Vec<Counter> {
-        mem::take(&mut self.counters)
-    }
 }
 
 impl field::Visit for FFIDebugAnnotations {

--- a/crates/layer/src/debug_annotations.rs
+++ b/crates/layer/src/debug_annotations.rs
@@ -1,12 +1,19 @@
 //! Internal module used to collect span attrs as Perfetto SDK
 //! `DebugAnnotation`s
+
+use std::mem;
+
 use schema::debug_annotation;
 use tracing::field;
 use tracing_perfetto_sdk_schema as schema;
+use tracing_perfetto_sdk_schema::track_event;
 use tracing_perfetto_sdk_sys::ffi;
+
+const COUNTER_FIELD_PREFIX: &str = "counter.";
 
 #[derive(Default)]
 pub struct FFIDebugAnnotations {
+    counters: Vec<Counter>,
     strings: Vec<ffi::DebugStringAnnotation>,
     bools: Vec<ffi::DebugBoolAnnotation>,
     ints: Vec<ffi::DebugIntAnnotation>,
@@ -15,7 +22,21 @@ pub struct FFIDebugAnnotations {
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct ProtoDebugAnnotations {
+    counters: Vec<Counter>,
     annotations: Vec<schema::DebugAnnotation>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Counter {
+    pub name: &'static str,
+    pub unit: Option<&'static str>,
+    pub value: CounterValue,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum CounterValue {
+    Float(f64),
+    Int(i64),
 }
 
 impl FFIDebugAnnotations {
@@ -27,30 +48,49 @@ impl FFIDebugAnnotations {
             doubles: self.doubles.as_slice(),
         }
     }
+
+    pub fn take_counters(&mut self) -> Vec<Counter> {
+        mem::take(&mut self.counters)
+    }
 }
 
 impl field::Visit for FFIDebugAnnotations {
     fn record_f64(&mut self, field: &field::Field, value: f64) {
-        self.doubles.push(ffi::DebugDoubleAnnotation {
-            key: field.name(),
-            value,
-        });
+        if !populate_counter(&mut self.counters, field, value) {
+            self.doubles.push(ffi::DebugDoubleAnnotation {
+                key: field.name(),
+                value,
+            });
+        }
     }
 
     fn record_i64(&mut self, field: &field::Field, value: i64) {
-        self.ints.push(ffi::DebugIntAnnotation {
-            key: field.name(),
-            value,
-        });
+        if !populate_counter(&mut self.counters, field, value) {
+            self.ints.push(ffi::DebugIntAnnotation {
+                key: field.name(),
+                value,
+            });
+        }
     }
 
     fn record_u64(&mut self, field: &field::Field, value: u64) {
-        if let Ok(v) = i64::try_from(value) {
-            self.ints.push(ffi::DebugIntAnnotation {
-                key: field.name(),
-                value: v,
-            });
-        } else {
+        if !populate_counter(&mut self.counters, field, value) {
+            if let Ok(v) = i64::try_from(value) {
+                self.ints.push(ffi::DebugIntAnnotation {
+                    key: field.name(),
+                    value: v,
+                });
+            } else {
+                self.strings.push(ffi::DebugStringAnnotation {
+                    key: field.name(),
+                    value: value.to_string(),
+                });
+            }
+        }
+    }
+
+    fn record_i128(&mut self, field: &field::Field, value: i128) {
+        if !populate_counter(&mut self.counters, field, value) {
             self.strings.push(ffi::DebugStringAnnotation {
                 key: field.name(),
                 value: value.to_string(),
@@ -58,18 +98,13 @@ impl field::Visit for FFIDebugAnnotations {
         }
     }
 
-    fn record_i128(&mut self, field: &field::Field, value: i128) {
-        self.strings.push(ffi::DebugStringAnnotation {
-            key: field.name(),
-            value: value.to_string(),
-        });
-    }
-
     fn record_u128(&mut self, field: &field::Field, value: u128) {
-        self.strings.push(ffi::DebugStringAnnotation {
-            key: field.name(),
-            value: value.to_string(),
-        });
+        if !populate_counter(&mut self.counters, field, value) {
+            self.strings.push(ffi::DebugStringAnnotation {
+                key: field.name(),
+                value: value.to_string(),
+            });
+        }
     }
 
     fn record_bool(&mut self, field: &field::Field, value: bool) {
@@ -106,6 +141,10 @@ impl ProtoDebugAnnotations {
         self.annotations
     }
 
+    pub fn take_counters(&mut self) -> Vec<Counter> {
+        mem::take(&mut self.counters)
+    }
+
     fn name_field(field: &field::Field) -> Option<debug_annotation::NameField> {
         Some(debug_annotation::NameField::Name(field.name().to_string()))
     }
@@ -113,29 +152,45 @@ impl ProtoDebugAnnotations {
 
 impl field::Visit for ProtoDebugAnnotations {
     fn record_f64(&mut self, field: &field::Field, value: f64) {
-        self.annotations.push(schema::DebugAnnotation {
-            name_field: Self::name_field(field),
-            value: Some(debug_annotation::Value::DoubleValue(value)),
-            ..Default::default()
-        });
+        if !populate_counter(&mut self.counters, field, value) {
+            self.annotations.push(schema::DebugAnnotation {
+                name_field: Self::name_field(field),
+                value: Some(debug_annotation::Value::DoubleValue(value)),
+                ..Default::default()
+            });
+        }
     }
 
     fn record_i64(&mut self, field: &field::Field, value: i64) {
-        self.annotations.push(schema::DebugAnnotation {
-            name_field: Self::name_field(field),
-            value: Some(debug_annotation::Value::IntValue(value)),
-            ..Default::default()
-        });
+        if !populate_counter(&mut self.counters, field, value) {
+            self.annotations.push(schema::DebugAnnotation {
+                name_field: Self::name_field(field),
+                value: Some(debug_annotation::Value::IntValue(value)),
+                ..Default::default()
+            });
+        }
     }
 
     fn record_u64(&mut self, field: &field::Field, value: u64) {
-        if let Ok(v) = i64::try_from(value) {
-            self.annotations.push(schema::DebugAnnotation {
-                name_field: Self::name_field(field),
-                value: Some(debug_annotation::Value::IntValue(v)),
-                ..Default::default()
-            });
-        } else {
+        if !populate_counter(&mut self.counters, field, value) {
+            if let Ok(v) = i64::try_from(value) {
+                self.annotations.push(schema::DebugAnnotation {
+                    name_field: Self::name_field(field),
+                    value: Some(debug_annotation::Value::IntValue(v)),
+                    ..Default::default()
+                });
+            } else {
+                self.annotations.push(schema::DebugAnnotation {
+                    name_field: Self::name_field(field),
+                    value: Some(debug_annotation::Value::StringValue(value.to_string())),
+                    ..Default::default()
+                });
+            }
+        }
+    }
+
+    fn record_i128(&mut self, field: &field::Field, value: i128) {
+        if !populate_counter(&mut self.counters, field, value) {
             self.annotations.push(schema::DebugAnnotation {
                 name_field: Self::name_field(field),
                 value: Some(debug_annotation::Value::StringValue(value.to_string())),
@@ -144,20 +199,14 @@ impl field::Visit for ProtoDebugAnnotations {
         }
     }
 
-    fn record_i128(&mut self, field: &field::Field, value: i128) {
-        self.annotations.push(schema::DebugAnnotation {
-            name_field: Self::name_field(field),
-            value: Some(debug_annotation::Value::StringValue(value.to_string())),
-            ..Default::default()
-        });
-    }
-
     fn record_u128(&mut self, field: &field::Field, value: u128) {
-        self.annotations.push(schema::DebugAnnotation {
-            name_field: Self::name_field(field),
-            value: Some(debug_annotation::Value::StringValue(value.to_string())),
-            ..Default::default()
-        });
+        if !populate_counter(&mut self.counters, field, value) {
+            self.annotations.push(schema::DebugAnnotation {
+                name_field: Self::name_field(field),
+                value: Some(debug_annotation::Value::StringValue(value.to_string())),
+                ..Default::default()
+            });
+        }
     }
 
     fn record_bool(&mut self, field: &field::Field, value: bool) {
@@ -190,5 +239,75 @@ impl field::Visit for ProtoDebugAnnotations {
             value: Some(debug_annotation::Value::StringValue(format!("{:?}", value))),
             ..Default::default()
         });
+    }
+}
+
+impl CounterValue {
+    pub fn to_proto(self) -> track_event::CounterValueField {
+        match self {
+            CounterValue::Float(v) => track_event::CounterValueField::DoubleCounterValue(v),
+            CounterValue::Int(v) => track_event::CounterValueField::CounterValue(v),
+        }
+    }
+}
+
+impl From<f64> for CounterValue {
+    fn from(value: f64) -> Self {
+        CounterValue::Float(value)
+    }
+}
+
+impl From<i64> for CounterValue {
+    fn from(value: i64) -> Self {
+        CounterValue::Int(value)
+    }
+}
+
+impl From<u64> for CounterValue {
+    fn from(value: u64) -> Self {
+        if let Ok(v) = i64::try_from(value) {
+            CounterValue::Int(v)
+        } else {
+            CounterValue::Float(value as f64)
+        }
+    }
+}
+
+impl From<i128> for CounterValue {
+    fn from(value: i128) -> Self {
+        if let Ok(v) = i64::try_from(value) {
+            CounterValue::Int(v)
+        } else {
+            CounterValue::Float(value as f64)
+        }
+    }
+}
+
+impl From<u128> for CounterValue {
+    fn from(value: u128) -> Self {
+        if let Ok(v) = i64::try_from(value) {
+            CounterValue::Int(v)
+        } else {
+            CounterValue::Float(value as f64)
+        }
+    }
+}
+
+fn populate_counter(
+    dest_counters: &mut Vec<Counter>,
+    field: &field::Field,
+    value: impl Into<CounterValue>,
+) -> bool {
+    if let Some(name) = field.name().strip_prefix(COUNTER_FIELD_PREFIX) {
+        let (name, unit) = name
+            .rsplit_once('.')
+            .map(|(n, u)| (n, Some(u)))
+            .unwrap_or_else(|| (name, None));
+
+        let value = value.into();
+        dest_counters.push(Counter { name, value, unit });
+        true
+    } else {
+        false
     }
 }

--- a/crates/layer/src/ids.rs
+++ b/crates/layer/src/ids.rs
@@ -15,6 +15,7 @@ const THREAD_NS: u32 = 2;
 const TOKIO_NS: u32 = 3;
 #[cfg(feature = "tokio")]
 const TASK_NS: u32 = 4;
+const COUNTER_NS: u32 = 5;
 
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[repr(transparent)]
@@ -41,6 +42,12 @@ impl TrackUuid {
     pub fn for_tokio() -> TrackUuid {
         let mut h = hash::DefaultHasher::new();
         (TRACK_UUID_NS, TOKIO_NS).hash(&mut h);
+        TrackUuid(h.finish())
+    }
+
+    pub fn for_counter(counter_name: &str) -> TrackUuid {
+        let mut h = hash::DefaultHasher::new();
+        (TRACK_UUID_NS, COUNTER_NS, counter_name).hash(&mut h);
         TrackUuid(h.finish())
     }
 

--- a/crates/layer/src/lib.rs
+++ b/crates/layer/src/lib.rs
@@ -1,5 +1,105 @@
 #![deny(clippy::all)]
-/// # `tracing-perfetto-sdk-layer`: A tracing layer that reports traces via the C++ Perfetto SDK
+//! # `tracing-perfetto-sdk-layer`
+//! A suite of tracing layers that reports traces via the C++ Perfetto SDK
+//!
+//! There are currently two flavors of layers:
+//!
+//!   * [`NativeLayer`]: Writes tracing data using Rust code, but can
+//!     additionally fetch further tracing data using the Perfetto SDK, e.g. via
+//!     the `traced` daemon.
+//!   * [`SdkLayer`]: Writes tracing data using the C++ SDK subroutines.  The
+//!     SDK then decides how/if/when it interacts with other things in the
+//!     Perfetto ecosystem.
+//!
+//! You can easily add a layer into your existing `tracing-subscriber` stack:
+//!
+//! ```no_run
+//! use std::{fs, thread, time};
+//! use tracing_subscriber::layer::SubscriberExt as _;
+//! use tracing_perfetto_sdk_layer::NativeLayer;
+//!
+//! let out_file = "native-layer-example.pftrace";
+//! let trace_config = todo!();
+//! let out_file = fs::File::create(out_file)?;
+//! let layer = NativeLayer::from_config(trace_config, out_file).build()?;
+//!
+//! let subscriber = tracing_subscriber::registry().with(layer);
+//!
+//! tracing::subscriber::with_default(subscriber, || {
+//!     tracing::info!(foo = "baz", int = 7, "hello trace!");
+//!
+//!     let span = tracing::info_span!("hi", foo = "bar", int = 3);
+//!     let guard = span.enter();
+//!     thread::sleep(time::Duration::from_secs(1));
+//!     drop(guard);
+//! });
+//! ```
+//!
+//! ## Using counters
+//!
+//! When logging trace events, such as when calling `tracing::info!()` and
+//! similar macros, it is possible to additionally specify counters that will be
+//! reported in the trace.
+//!
+//! Any field within the trace event can be a counter if it starts with the
+//! `counter.` prefix and has a numeric value:
+//!
+//! ```no_run
+//! tracing::info!(counter.mem_usage=42, counter.cpu_usage=23.2, "hi!");
+//! ```
+//!
+//! It is recommended to specify the unit of the counter as the last
+//! `.`-separated part of the field:
+//!
+//! ```no_run
+//! tracing::info!(counter.mem_usage.bytes=42, counter.cpu_usage.percent=23.2, "hi!");
+//! ```
+//!
+//! **NOTE**: at the time of writing, counters are only implemented by the
+//! [`NativeLayer`].
+//!
+//! ## Controlling output destinations
+//!
+//! For [`NativeLayer`], traces can be written to anything that implements the
+//! [`tracing_subscriber::fmt::MakeWriter`] trait.  It might be a good idea to
+//! use the [`tracing_appender::non_blocking`] output if you want to defer the
+//! writing to actual disk to a background thread.
+//!
+//! For [`SdkLayer`], since the write operation happens in C++ code, a real file
+//! with an open file descriptor must be used instead.
+//!
+//! ## Tokio support
+//!
+//! If the `tokio` feature is enabled, the layers will be aware of spans coming
+//! from the `tokio` runtime vs. normal OS threads.  Spans coming from the
+//! `tokio` runtime will be reported to a special `tokio-runtime` track.
+//!
+//! ## Forcing flavors
+//!
+//! The layers will report spans to Perfetto using either a sync or async
+//! flavor:
+//!
+//!  * The sync flavor implies that spans are reported when they are entered and
+//!    exited.
+//!  * The async flavor implies that spans are reported using RAII semantics, ie
+//!    upon construction and until they are dropped.
+//!
+//! By default, a heuristic is used to determine whether a span is sync or
+//! async. A specific flavor can instead be forced using the
+//! `.with_force_flavor` method on layer builders.
+//!
+//! ## In-process vs system mode
+//!
+//! By default, layers are configured to run in-process mode only. That means
+//! that the only data sources that are consulted are the ones embedded in the
+//! actual application binary.
+//!
+//! In addition, (or instead of) in-process mode, the system mode can be
+//! activated too.  This will (in the case of [`SdkLayer`]) write traces to the
+//! system's `traced` daemon, or (in the case of [`NativeLayer`]) poll for
+//! system-wide traces from the `traced` daemon and include them in the trace
+//! file.
+
 // Internal modules:
 mod debug_annotations;
 mod ffi_utils;

--- a/crates/layer/src/lib.rs
+++ b/crates/layer/src/lib.rs
@@ -20,8 +20,8 @@
 //!
 //! let out_file = "native-layer-example.pftrace";
 //! let trace_config = todo!();
-//! let out_file = fs::File::create(out_file)?;
-//! let layer = NativeLayer::from_config(trace_config, out_file).build()?;
+//! let out_file = fs::File::create(out_file).unwrap();
+//! let layer = NativeLayer::from_config(trace_config, out_file).build().unwrap();
 //!
 //! let subscriber = tracing_subscriber::registry().with(layer);
 //!

--- a/crates/layer/tests/kitchen_sink.rs
+++ b/crates/layer/tests/kitchen_sink.rs
@@ -6,6 +6,7 @@ use tokio::{runtime, time};
 use tracing::{info, span};
 use tracing_perfetto_sdk_layer as layer;
 use tracing_perfetto_sdk_schema as schema;
+use tracing_perfetto_sdk_schema::track_descriptor;
 use tracing_subscriber::fmt;
 use tracing_subscriber::fmt::format;
 
@@ -61,7 +62,7 @@ data_sources:
     let demo_span = span!(tracing::Level::TRACE, "demo_span");
     let enter = demo_span.enter();
 
-    info!("in span");
+    info!(counter.foo_counter.ms = 42, "in span");
     sync_fn(1);
     sync_fn(2);
     let handle = runtime::Handle::current();
@@ -133,7 +134,31 @@ data_sources:
 
     assert_eq!(process_td.uuid, tokio_td.parent_uuid);
 
+    let counter_td = trace
+        .packet
+        .iter()
+        .find_map(|p| {
+            let td = as_track_descriptor(p)?;
+            if td_name(td) == "foo_counter" && td.counter.is_some() {
+                Some(td)
+            } else {
+                None
+            }
+        })
+        .expect("to find a track descriptor for the foo_counter counter");
+
+    let counter_def = counter_td.counter.as_ref().unwrap();
+    assert_eq!(counter_def.unit_name.as_ref().unwrap(), "ms");
+
     Ok(())
+}
+
+fn td_name(track_descriptor: &schema::TrackDescriptor) -> &str {
+    match track_descriptor.static_or_dynamic_name {
+        Some(track_descriptor::StaticOrDynamicName::Name(ref str)) => str,
+        Some(track_descriptor::StaticOrDynamicName::StaticName(ref str)) => str,
+        None => "",
+    }
 }
 
 fn as_track_descriptor(packet: &schema::TracePacket) -> Option<&schema::TrackDescriptor> {

--- a/crates/layer/tests/kitchen_sink.rs
+++ b/crates/layer/tests/kitchen_sink.rs
@@ -163,7 +163,10 @@ data_sources:
         })
         .expect("to find a track event for a counter value");
 
-    assert_eq!(counter_value_event, &track_event::CounterValueField::CounterValue(42));
+    assert_eq!(
+        counter_value_event,
+        &track_event::CounterValueField::CounterValue(42)
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Adds support for reporting counters through trace events (e.g. in a `tracing::info!()` call or similar).

While I was at it, I added some crate-level documentation, so please refer to the documentation in `lib.rs` to check if the API makes sense!