### PR TITLE
native_layer: Add sequence id to counter events

### DIFF
--- a/crates/layer/src/ids.rs
+++ b/crates/layer/src/ids.rs
@@ -70,6 +70,12 @@ impl SequenceId {
         SequenceId(h.finish() as u32)
     }
 
+    pub fn for_counter(counter_name: &str) -> SequenceId {
+        let mut h = hash::DefaultHasher::new();
+        (SEQUENCE_ID_NS, COUNTER_NS, counter_name).hash(&mut h);
+        SequenceId(h.finish() as u32)
+    }
+
     pub fn as_raw(self) -> u32 {
         self.0
     }

--- a/crates/layer/src/native_layer.rs
+++ b/crates/layer/src/native_layer.rs
@@ -437,6 +437,11 @@ where
     fn write_counter_event(&self, meta: &tracing::Metadata, counter: debug_annotations::Counter) {
         let packet = schema::TracePacket {
             timestamp: Some(ffi::trace_time_ns()),
+            optional_trusted_packet_sequence_id: Some(
+                trace_packet::OptionalTrustedPacketSequenceId::TrustedPacketSequenceId(
+                    ids::SequenceId::for_counter(counter.name).as_raw(),
+                ),
+            ),
             data: Some(trace_packet::Data::TrackEvent(schema::TrackEvent {
                 r#type: Some(track_event::Type::Counter as i32),
                 track_uuid: Some(ids::TrackUuid::for_counter(counter.name).as_raw()),


### PR DESCRIPTION
Populates the `sequence_id`, hopefully improving the visualization in the Perfetto UI