### PR TITLE
debug_annotations: Add support for fully suppressing an event via a field

### DIFF
--- a/crates/layer/src/lib.rs
+++ b/crates/layer/src/lib.rs
@@ -91,6 +91,16 @@
 //! **NOTE**: at the time of writing, counters are only implemented by the
 //! [`NativeLayer`].
 //!
+//! ## Suppressing events
+//!
+//! Sometimes, you want to log a tracing event but have it be suppressed in the
+//! Perfetto trace in particular. You can set the `perfetto.suppress_event =
+//! true` field for that to happen:
+//!
+//! ```no_run
+//! tracing::info!(perfetto.suppress_event=true, "won't be included in the Perfetto trace");
+//! ```
+//!
 //! ## Controlling output destinations
 //!
 //! For [`NativeLayer`], traces can be written to anything that implements the

--- a/crates/layer/src/native_layer.rs
+++ b/crates/layer/src/native_layer.rs
@@ -775,8 +775,10 @@ where
         event.record(&mut debug_annotations);
         self.report_counters(meta, debug_annotations.take_counters());
 
-        let (track_uuid, sequence_id, _) = self.pick_trace_track_sequence();
-        self.report_event(meta, debug_annotations, track_uuid, sequence_id);
+        if !debug_annotations.suppress_event() {
+            let (track_uuid, sequence_id, _) = self.pick_trace_track_sequence();
+            self.report_event(meta, debug_annotations, track_uuid, sequence_id);
+        }
     }
 
     fn on_enter(&self, id: &span::Id, ctx: layer::Context<'_, S>) {

--- a/crates/layer/src/sdk_layer.rs
+++ b/crates/layer/src/sdk_layer.rs
@@ -267,15 +267,17 @@ where
         let mut debug_annotations = debug_annotations::FFIDebugAnnotations::default();
         event.record(&mut debug_annotations);
 
-        let meta = event.metadata();
-        let (track_uuid, _) = self.pick_trace_track();
-        ffi::trace_track_event_instant(
-            track_uuid.as_raw(),
-            meta.name(),
-            meta.file().unwrap_or_default(),
-            meta.line().unwrap_or_default(),
-            &debug_annotations.as_ffi(),
-        );
+        if !debug_annotations.suppress_event() {
+            let meta = event.metadata();
+            let (track_uuid, _) = self.pick_trace_track();
+            ffi::trace_track_event_instant(
+                track_uuid.as_raw(),
+                meta.name(),
+                meta.file().unwrap_or_default(),
+                meta.line().unwrap_or_default(),
+                &debug_annotations.as_ffi(),
+            );
+        }
     }
 
     fn on_enter(&self, id: &span::Id, ctx: layer::Context<'_, S>) {


### PR DESCRIPTION
Allows users to tag events that should not be included in the perfetto trace