### PR TITLE
sys/native: Set timestamp clock correctly in generated packets

### DIFF
--- a/crates/sys/src/lib.rs
+++ b/crates/sys/src/lib.rs
@@ -165,6 +165,12 @@ pub mod ffi {
         /// clock(s).
         fn trace_time_ns() -> u64;
 
+        /// Get the id of the clock that is used by `trace_time_ns`.
+        ///
+        /// Valid values correspond to enum variants of the `BuiltinClock`
+        /// protobuf enum.
+        fn trace_clock_id() -> u32;
+
         /// Start collecting traces from all data sources.
         fn start(self: Pin<&mut PerfettoTracingSession>);
 

--- a/crates/sys/src/perfetto-bindings.cc
+++ b/crates/sys/src/perfetto-bindings.cc
@@ -306,3 +306,5 @@ void trace_track_descriptor_thread(uint64_t parent_uuid, uint64_t track_uuid,
 }
 
 uint64_t trace_time_ns() { return perfetto::TrackEvent::GetTraceTimeNs(); }
+
+uint32_t trace_clock_id() { return perfetto::TrackEvent::GetTraceClockId(); }

--- a/crates/sys/src/perfetto-bindings.h
+++ b/crates/sys/src/perfetto-bindings.h
@@ -63,3 +63,5 @@ void trace_track_descriptor_thread(uint64_t parent_uuid, uint64_t track_uuid,
                                    uint32_t thread_tid);
 
 uint64_t trace_time_ns();
+
+uint32_t trace_clock_id();


### PR DESCRIPTION
Populates a field that we didn't use to populate previously.