### PR TITLE
native_layer: Add support for creating async task tracks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +326,12 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
@@ -335,7 +355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.0",
 ]
 
 [[package]]
@@ -397,6 +417,16 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -482,6 +512,19 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
 
 [[package]]
 name = "pbjson"
@@ -630,6 +673,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,6 +734,12 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scratch"
@@ -940,6 +998,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cxx",
+ "dashmap",
  "nix",
  "prost",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = "1.0.90"
 bytes = "1.8.0"
 cxx = { version = "1.0.129", features = ["c++17"] }
 cxx-build = { version = "1.0.129", features = ["parallel"] }
+dashmap = "6.1.0"
 futures = "0.3.31"
 nix =  "0.29.0"
 pbjson = "0.6.0"

--- a/crates/layer/Cargo.toml
+++ b/crates/layer/Cargo.toml
@@ -9,6 +9,7 @@ edition.workspace = true
 [dependencies]
 bytes.workspace = true
 cxx.workspace = true
+dashmap.workspace = true
 nix = { workspace = true, features = ["time"] }
 prost.workspace = true
 thiserror.workspace = true

--- a/crates/layer/src/ids.rs
+++ b/crates/layer/src/ids.rs
@@ -39,6 +39,13 @@ impl TrackUuid {
     }
 
     #[cfg(feature = "tokio")]
+    pub fn for_task(id: task::Id) -> TrackUuid {
+        let mut h = hash::DefaultHasher::new();
+        (TRACK_UUID_NS, TASK_NS, id).hash(&mut h);
+        TrackUuid(h.finish())
+    }
+
+    #[cfg(feature = "tokio")]
     pub fn for_tokio() -> TrackUuid {
         let mut h = hash::DefaultHasher::new();
         (TRACK_UUID_NS, TOKIO_NS).hash(&mut h);
@@ -66,7 +73,7 @@ impl SequenceId {
     #[cfg(feature = "tokio")]
     pub fn for_task(id: task::Id) -> SequenceId {
         let mut h = hash::DefaultHasher::new();
-        (TRACK_UUID_NS, TASK_NS, id).hash(&mut h);
+        (SEQUENCE_ID_NS, TASK_NS, id).hash(&mut h);
         SequenceId(h.finish() as u32)
     }
 


### PR DESCRIPTION
This is valuable when having a lot of async/concurrent operations. By emitting tracks for async tasks, we can correlate spans emitted from that same task in that they preserve some parent/child semantics. To have the Perfetto UI not break completely, these tracks all have to have the same name so that they are collapsed in the UI.