### PR TITLE
pin GitHub Actions by hash

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,9 +13,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
+      uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
     - name: Build
       run: cargo build --all
     - name: Run tests
@@ -23,9 +23,9 @@ jobs:
   build-no-default-features:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
+      uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
     - name: Build
       run: cargo build --all --no-default-features
     - name: Run tests
@@ -33,9 +33,9 @@ jobs:
   build-tokio:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
+      uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
     - name: Build
       run: cargo build --all --features=tokio
     - name: Run tests
@@ -43,9 +43,9 @@ jobs:
   build-serde:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
+      uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
     - name: Build
       run: cargo build --all --features=serde
     - name: Run tests
@@ -53,9 +53,9 @@ jobs:
   build-serde-tokio:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
+      uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
     - name: Build
       run: cargo build --all --features=serde,tokio
     - name: Run tests


### PR DESCRIPTION
See [SEC-48](https://linear.app/modal-labs/issue/SEC-48/pin-all-github-actions-that-we-use-to-a-specific-hash) and [VULN-32](https://linear.app/modal-labs/issue/VULN-32/gh-actions-runner-secrets-potentially-leaked-via-compromised-tj) for context.