### PR TITLE
parametrize producer name

### DIFF
--- a/crates/layer/src/init.rs
+++ b/crates/layer/src/init.rs
@@ -2,10 +2,11 @@
 use tracing_perfetto_sdk_sys::ffi;
 
 #[allow(unused_variables)]
-pub fn global_init(enable_in_process_backend: bool, enable_system_backend: bool) {
+pub fn global_init(name: &str, enable_in_process_backend: bool, enable_system_backend: bool) {
     #[cfg(feature = "sdk")]
     ffi::perfetto_global_init(
         log_callback,
+        name,
         enable_in_process_backend,
         enable_system_backend,
     );

--- a/crates/layer/src/native_layer.rs
+++ b/crates/layer/src/native_layer.rs
@@ -47,6 +47,7 @@ pub struct Builder<'c, W> {
     create_async_tracks: Option<String>,
     enable_in_process: bool,
     enable_system: bool,
+    name: &'c str,
     _phantom: marker::PhantomData<&'c ()>,
 }
 
@@ -116,7 +117,7 @@ where
 
     fn build(builder: Builder<'_, W>) -> error::Result<Self> {
         // Shared global initialization for all layers
-        init::global_init(builder.enable_in_process, builder.enable_system);
+        init::global_init(builder.name, builder.enable_in_process, builder.enable_system);
 
         let writer = sync::Arc::new(builder.writer);
 
@@ -922,8 +923,15 @@ where
             create_async_tracks: None,
             enable_in_process: true,
             enable_system: false,
+            name: "rust_tracing",
             _phantom: marker::PhantomData,
         }
+    }
+
+    /// Set the name for perfetto to producer. This name will have to be specified in a data source.
+    pub fn with_name(mut self, name: &'c str) -> Self {
+        self.name = name;
+        self
     }
 
     /// If `Some`, force the specified trace flavor. If `None`, use heuristics

--- a/crates/layer/src/sdk_layer.rs
+++ b/crates/layer/src/sdk_layer.rs
@@ -27,6 +27,7 @@ pub struct Builder<'c> {
     drop_flush_timeout: time::Duration,
     enable_in_process: bool,
     enable_system: bool,
+    name: &'c str,
 }
 
 struct ThreadLocalCtx {
@@ -85,7 +86,7 @@ impl SdkLayer {
         use std::os::fd::AsRawFd as _;
 
         // Shared global initialization for all layers
-        init::global_init(builder.enable_in_process, builder.enable_system);
+        init::global_init(builder.name, builder.enable_in_process, builder.enable_system);
 
         let fd = builder
             .output_file
@@ -379,7 +380,14 @@ impl<'c> Builder<'c> {
             drop_flush_timeout: time::Duration::from_millis(100),
             enable_in_process: true,
             enable_system: false,
+            name: "rust_tracing",
         }
+    }
+
+    /// Set the name for perfetto to producer. This name will have to be specified in a data source.
+    pub fn with_name(mut self, name: &'c str) -> Self {
+        self.name = name;
+        self
     }
 
     /// Enable in-process collection, where traces will be collected by buffers

--- a/crates/sys/src/lib.rs
+++ b/crates/sys/src/lib.rs
@@ -63,6 +63,7 @@ pub mod ffi {
         /// Must be called once before all other functions in this module.
         fn perfetto_global_init(
             log_callback: fn(level: LogLev, line: i32, filename: &str, message: &str),
+            name: &str,
             enable_in_process_backend: bool,
             enable_system_backend: bool,
         );

--- a/crates/sys/src/perfetto-bindings.cc
+++ b/crates/sys/src/perfetto-bindings.cc
@@ -1,8 +1,6 @@
 #include "perfetto-bindings.h"
 #include <stdexcept>
 
-const char *const RUST_TRACING_DATA_SOURCE_NAME = "rust_tracing";
-
 class RustTracingDataSource
     : public perfetto::DataSource<RustTracingDataSource> {
 public:
@@ -29,6 +27,7 @@ static void _log_callback_wrapper(perfetto::LogMessageCallbackArgs args) {
 }
 
 void perfetto_global_init(LogCallback log_callback,
+                          rust::Str name,
                           bool enable_in_process_backend,
                           bool enable_system_backend) {
   perfetto::TracingInitArgs args;
@@ -50,7 +49,7 @@ void perfetto_global_init(LogCallback log_callback,
 
   // Register Rust tracing support as a custom data source
   perfetto::DataSourceDescriptor dsd;
-  dsd.set_name(RUST_TRACING_DATA_SOURCE_NAME);
+  dsd.set_name(std::string(name));
   RustTracingDataSource::Register(dsd);
 }
 

--- a/crates/sys/src/perfetto-bindings.h
+++ b/crates/sys/src/perfetto-bindings.h
@@ -18,6 +18,7 @@ using PollTracesCallback =
 using FlushCallback = rust::Fn<void(rust::Box<FlushCtx> ctx, bool success)>;
 
 void perfetto_global_init(LogCallback log_callback,
+                          rust::Str name,
                           bool enable_in_process_backend,
                           bool enable_system_backend);
 

--- a/crates/sys/tests/happy_path.rs
+++ b/crates/sys/tests/happy_path.rs
@@ -3,7 +3,7 @@ use tracing_perfetto_sdk_sys::ffi;
 // This is in its own test file to get a new process for this test
 #[test]
 fn happy_path() {
-    ffi::perfetto_global_init(|_, _, _, _| {}, false, false);
+    ffi::perfetto_global_init(|_, _, _, _| {}, "rust_tracing", false, false);
     let result = ffi::new_tracing_session(&[], -1);
     assert!(result.is_ok());
 }

--- a/crates/sys/tests/invalid_config.rs
+++ b/crates/sys/tests/invalid_config.rs
@@ -3,7 +3,7 @@ use tracing_perfetto_sdk_sys::ffi;
 // This is in its own test file to get a new process for this test
 #[test]
 fn invalid_config() {
-    ffi::perfetto_global_init(|_, _, _, _| {}, false, false);
+    ffi::perfetto_global_init(|_, _, _, _| {}, "rust_tracing", false, false);
     let result = ffi::new_tracing_session(&[0x01], -1);
     if let Err(e) = result {
         let expected =


### PR DESCRIPTION
so that consumer can select which source to use, for example a specific service.

```rs
    let layer = tracing_perfetto_sdk_layer::SdkLayer::from_config(trace_config(), None)
        .with_enable_in_process(false)
        .with_enable_system(true)
        .with_name("example")
        .build()
```

and on the consumer side

```
data_sources {
  config {
    name: "example"
  }
}
```