### PR TITLE
Name async/thread tracks from the OS thread name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.13.1"
 edition = "2024"
 
 [workspace.dependencies]
+libc = "0.2"
 tracing-perfetto-sdk-layer = { version = "0.13.1", path = "crates/layer" }
 tracing-perfetto-sdk-schema = { version = "0.13.1", path = "crates/schema" }
 tracing-perfetto-sdk-sys = { version = "0.13.1", path = "crates/sys" }

--- a/crates/layer/Cargo.toml
+++ b/crates/layer/Cargo.toml
@@ -21,6 +21,11 @@ tracing-perfetto-sdk-schema.workspace = true
 tracing-perfetto-sdk-sys = { workspace = true, optional = true }
 tracing-subscriber.workspace = true
 
+# Used only to read the OS thread name (pthread_getname_np). Windows uses a
+# small inline kernel32 declaration instead, so needs no extra dependency.
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
+
 [dev-dependencies]
 anyhow.workspace = true
 serde_yaml.workspace = true

--- a/crates/layer/src/ids.rs
+++ b/crates/layer/src/ids.rs
@@ -91,3 +91,77 @@ impl SequenceId {
 pub(crate) fn thread_id() -> usize {
     os_id::thread::get_raw_id() as usize
 }
+
+/// Returns the OS-level name of the current thread, if it has one.
+///
+/// Unlike [`std::thread::Thread::name`] this also sees threads created outside
+/// of Rust (for example by C libraries such as GLib), which never carry a
+/// Rust-side name. Returns `None` on platforms where the name cannot be
+/// queried.
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "macos",
+    target_os = "ios"
+))]
+pub(crate) fn os_thread_name() -> Option<String> {
+    // The name is set via pthread_setname_np / prctl(PR_SET_NAME); 64 bytes is
+    // larger than every platform's limit.
+    let mut buf = [0 as libc::c_char; 64];
+    // SAFETY: `buf` is a valid, writable buffer of `buf.len()` bytes.
+    let ret =
+        unsafe { libc::pthread_getname_np(libc::pthread_self(), buf.as_mut_ptr(), buf.len()) };
+    if ret != 0 {
+        return None;
+    }
+    // SAFETY: on success the buffer holds a NUL-terminated C string.
+    let name = unsafe { std::ffi::CStr::from_ptr(buf.as_ptr()) };
+    match name.to_str() {
+        Ok(s) if !s.is_empty() => Some(s.to_owned()),
+        _ => None,
+    }
+}
+
+#[cfg(windows)]
+pub(crate) fn os_thread_name() -> Option<String> {
+    use std::ffi::c_void;
+
+    // Minimal kernel32 declarations to avoid pulling in a Win32 binding crate
+    // just for the thread name. The name is set via SetThreadDescription.
+    #[link(name = "kernel32")]
+    unsafe extern "system" {
+        fn GetCurrentThread() -> *mut c_void;
+        fn GetThreadDescription(thread: *mut c_void, description: *mut *mut u16) -> i32;
+        fn LocalFree(mem: *mut c_void) -> *mut c_void;
+    }
+
+    let mut wide: *mut u16 = std::ptr::null_mut();
+    // SAFETY: `GetCurrentThread` is a pseudo-handle that needs no closing;
+    // `GetThreadDescription` writes an owned UTF-16 string pointer into `wide`.
+    let hr = unsafe { GetThreadDescription(GetCurrentThread(), &mut wide) };
+    // `hr` is an HRESULT; negative means failure (SUCCEEDED(hr) == hr >= 0).
+    if hr < 0 || wide.is_null() {
+        return None;
+    }
+    // SAFETY: on success `wide` points to a NUL-terminated UTF-16 string that we
+    // must release with `LocalFree`.
+    let mut len = 0usize;
+    while unsafe { *wide.add(len) } != 0 {
+        len += 1;
+    }
+    let name = String::from_utf16_lossy(unsafe { std::slice::from_raw_parts(wide, len) });
+    // SAFETY: `wide` was allocated by `GetThreadDescription`.
+    unsafe { LocalFree(wide as *mut c_void) };
+    if name.is_empty() { None } else { Some(name) }
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "macos",
+    target_os = "ios",
+    windows
+)))]
+pub(crate) fn os_thread_name() -> Option<String> {
+    None
+}

--- a/crates/layer/src/native_layer.rs
+++ b/crates/layer/src/native_layer.rs
@@ -46,6 +46,7 @@ pub struct Builder<'c, W> {
     delay_slice_begin: bool,
     discard_tracing_data: bool,
     create_async_tracks: Option<String>,
+    real_thread_tracks: bool,
     enable_in_process: bool,
     enable_system: bool,
     name: &'c str,
@@ -66,6 +67,7 @@ where
     delay_slice_begin: bool,
     discard_tracing_data: bool,
     create_async_tracks: Option<String>,
+    real_thread_tracks: bool,
     process_track_uuid: ids::TrackUuid,
     process_descriptor_sent: atomic::AtomicBool,
     #[cfg(feature = "tokio")]
@@ -159,6 +161,7 @@ where
         let delay_slice_begin = builder.delay_slice_begin;
         let discard_tracing_data = builder.discard_tracing_data;
         let create_async_tracks = builder.create_async_tracks;
+        let real_thread_tracks = builder.real_thread_tracks;
         let pid = process::id();
         let process_track_uuid = ids::TrackUuid::for_process(pid);
         let process_descriptor_sent = atomic::AtomicBool::new(false);
@@ -181,6 +184,7 @@ where
             delay_slice_begin,
             discard_tracing_data,
             create_async_tracks,
+            real_thread_tracks,
             process_track_uuid,
             process_descriptor_sent,
             #[cfg(feature = "tokio")]
@@ -420,10 +424,14 @@ where
                 .map(|s| s.to_owned())
                 .or_else(crate::ids::os_thread_name)
                 .unwrap_or_else(|| format!("(unnamed thread {thread_id})"));
-            let packet = if let Some(ref name) = self.inner.create_async_tracks {
-                self.create_thread_track_descriptor(thread_id, name.to_owned(), false)
-            } else {
-                self.create_thread_track_descriptor(thread_id, thread_name, true)
+            let packet = match self.inner.create_async_tracks {
+                // Light-weight per-thread async track (the default): a named
+                // track without a ThreadDescriptor.
+                Some(ref name) if !self.inner.real_thread_tracks => {
+                    self.create_thread_track_descriptor(thread_id, name.to_owned(), false)
+                }
+                // Sync tracks, or async tracks promoted to real thread tracks.
+                _ => self.create_thread_track_descriptor(thread_id, thread_name, true),
             };
             self.write_packet(meta, packet);
         }
@@ -932,6 +940,7 @@ where
             delay_slice_begin: false,
             discard_tracing_data: false,
             create_async_tracks: None,
+            real_thread_tracks: false,
             enable_in_process: true,
             enable_system: false,
             name: "rust_tracing",
@@ -984,6 +993,20 @@ where
     /// trade-off is some data inflation and a laggier UI as a result.
     pub fn with_create_async_tracks(mut self, create_async_tracks: Option<String>) -> Self {
         self.create_async_tracks = create_async_tracks;
+        self
+    }
+
+    /// When per-thread async tracks are created (see
+    /// [`Self::with_create_async_tracks`]), emit them as real thread tracks
+    /// (with a `ThreadDescriptor` named from the OS thread name) instead of
+    /// light-weight tracks, so Perfetto groups and labels them as threads.
+    ///
+    /// This only affects the per-OS-thread tracks (a bounded set); per-task
+    /// async tracks remain light-weight. Useful for thread-based, non-async
+    /// workloads (e.g. C libraries such as GStreamer) where each track really
+    /// is a distinct OS thread. Defaults to `false`.
+    pub fn with_real_thread_tracks(mut self, real_thread_tracks: bool) -> Self {
+        self.real_thread_tracks = real_thread_tracks;
         self
     }
 

--- a/crates/layer/src/native_layer.rs
+++ b/crates/layer/src/native_layer.rs
@@ -118,7 +118,11 @@ where
 
     fn build(builder: Builder<'_, W>) -> error::Result<Self> {
         // Shared global initialization for all layers
-        init::global_init(builder.name, builder.enable_in_process, builder.enable_system);
+        init::global_init(
+            builder.name,
+            builder.enable_in_process,
+            builder.enable_system,
+        );
 
         let writer = sync::Arc::new(builder.writer);
 
@@ -408,9 +412,13 @@ where
     fn ensure_thread_known(&self, meta: &tracing::Metadata) {
         let thread_id = thread_id();
         if self.inner.thread_tracks_sent.insert(thread_id) {
+            // Fall back to the OS thread name (e.g. set by GLib/C libraries via
+            // pthread_setname_np) for threads created outside Rust, which carry
+            // no Rust-side name.
             let thread_name = thread::current()
                 .name()
                 .map(|s| s.to_owned())
+                .or_else(crate::ids::os_thread_name)
                 .unwrap_or_else(|| format!("(unnamed thread {thread_id})"));
             let packet = if let Some(ref name) = self.inner.create_async_tracks {
                 self.create_thread_track_descriptor(thread_id, name.to_owned(), false)
@@ -931,7 +939,8 @@ where
         }
     }
 
-    /// Set the name for perfetto to producer. This name will have to be specified in a data source.
+    /// Set the name for perfetto to producer. This name will have to be
+    /// specified in a data source.
     pub fn with_name(mut self, name: &'c str) -> Self {
         self.name = name;
         self


### PR DESCRIPTION
When using `NativeLayer` with `with_force_flavor(Async)` +
`with_create_async_tracks(...)` to trace a non-tokio, thread-based application
(in our case GStreamer), every per-thread track showed up either as
`(unnamed thread N)` or with the single generic `create_async_tracks` label, so
it was impossible to tell the threads apart in the Perfetto UI.

## Commits:
- **layer: fall back to the OS thread name for thread tracks**    
  std::thread::Thread::name() only reflects threads named through Rust, so
  threads spawned by C libraries (e.g. GLib) showed up as "(unnamed thread
  N)". When the Rust name is absent, fall back to the OS thread name:
  pthread_getname_np() on Linux/Android/macOS/iOS and GetThreadDescription()
  on Windows. Other targets keep returning None.

- **layer: add with_real_thread_tracks() for per-thread async tracks**    
  With create_async_tracks, per-OS-thread async tracks are light-weight
  named tracks (no ThreadDescriptor), so Perfetto does not group them as
  threads. Add an opt-in with_real_thread_tracks() that emits them as real
  thread tracks named from the OS thread name. Per-task tracks (potentially
  many) stay light-weight. Off by default.